### PR TITLE
Add attributes for Panel

### DIFF
--- a/lib/ratatouille/renderer/element.ex
+++ b/lib/ratatouille/renderer/element.ex
@@ -83,10 +83,12 @@ defmodule Ratatouille.Renderer.Element do
       renderer: Panel,
       child_tags: [:table, :row, :label, :panel, :chart, :sparkline, :tree],
       attributes: [
+        color: {:optional, "Color of title"},
+        background: {:optional, "Background of title"},
         height:
           {:optional,
            "Height of the table in rows or `:fill` to fill the parent container's box"},
-        title: {:optional, "Binary containing the title for the panel"}
+        title: {:optional, "Binary containing the title for the panel"},
       ]
     ],
     row: [

--- a/lib/ratatouille/renderer/element.ex
+++ b/lib/ratatouille/renderer/element.ex
@@ -88,7 +88,7 @@ defmodule Ratatouille.Renderer.Element do
         height:
           {:optional,
            "Height of the table in rows or `:fill` to fill the parent container's box"},
-        title: {:optional, "Binary containing the title for the panel"},
+        title: {:optional, "Binary containing the title for the panel"}
       ]
     ],
     row: [

--- a/lib/ratatouille/renderer/element/panel.ex
+++ b/lib/ratatouille/renderer/element/panel.ex
@@ -50,18 +50,15 @@ defmodule Ratatouille.Renderer.Element.Panel do
   defp render_features(canvas, attrs) do
     canvas
     |> Border.render()
-    |> render_title(attrs[:title])
+    |> render_title(attrs)
   end
 
   defp render_title(canvas, nil), do: canvas
 
-  defp render_title(%Canvas{render_box: box} = canvas, title) when is_binary(title) do
-    Text.render(canvas, title_position(box), title)
+  defp render_title(%Canvas{render_box: box} = canvas, %{title: title}=attr) when is_binary(title) do
+    Text.render(canvas, title_position(box), title, attr)
   end
-
-  defp render_title(%Canvas{render_box: box} = canvas, {title, attributes}) do
-    Text.render(canvas, title_position(box), title, attributes)
-  end
+  defp render_title(canvas, _), do: canvas
 
   defp title_position(box),
     do: Position.translate_x(box.top_left, @title_offset_x)

--- a/lib/ratatouille/renderer/element/panel.ex
+++ b/lib/ratatouille/renderer/element/panel.ex
@@ -55,9 +55,11 @@ defmodule Ratatouille.Renderer.Element.Panel do
 
   defp render_title(canvas, nil), do: canvas
 
-  defp render_title(%Canvas{render_box: box} = canvas, %{title: title}=attr) when is_binary(title) do
+  defp render_title(%Canvas{render_box: box} = canvas, %{title: title} = attr)
+       when is_binary(title) do
     Text.render(canvas, title_position(box), title, attr)
   end
+
   defp render_title(canvas, _), do: canvas
 
   defp title_position(box),

--- a/lib/ratatouille/renderer/element/panel.ex
+++ b/lib/ratatouille/renderer/element/panel.ex
@@ -55,8 +55,12 @@ defmodule Ratatouille.Renderer.Element.Panel do
 
   defp render_title(canvas, nil), do: canvas
 
-  defp render_title(%Canvas{render_box: box} = canvas, title) do
+  defp render_title(%Canvas{render_box: box} = canvas, title) when is_binary(title) do
     Text.render(canvas, title_position(box), title)
+  end
+
+  defp render_title(%Canvas{render_box: box} = canvas, {title, attributes}) do
+    Text.render(canvas, title_position(box), title, attributes)
   end
 
   defp title_position(box),

--- a/test/ratatouille/renderer/element/panel_test.exs
+++ b/test/ratatouille/renderer/element/panel_test.exs
@@ -5,10 +5,15 @@ defmodule Ratatouille.Renderer.Element.PanelTest do
   alias Ratatouille.Renderer.{Canvas, Element.Panel}
 
   import Ratatouille.View
+  import Ratatouille.Constants, only: [color: 1]
 
   @panel_with_title (panel title: "The Title" do
                        label(content: "Body content")
                      end)
+
+  @panel_with_highlighted_title (panel title: {"Highlighted Title", [color: color(:red)] } do
+                       label(content: "Body contentt")
+    end)
 
   @panel_with_explicit_height panel(height: 5)
 
@@ -50,6 +55,23 @@ defmodule Ratatouille.Renderer.Element.PanelTest do
       assert Canvas.render_to_strings(canvas) ===
                [
                  "┌─The Title────┐",
+                 "│              │",
+                 "│ Body content │",
+                 "└──────────────┘"
+               ]
+    end
+
+    test "renders border and highlighted title" do
+      canvas =
+        Panel.render(
+          Canvas.from_dimensions(16, 4),
+          @panel_with_highlighted_title,
+          &Renderer.render_tree/2
+        )
+
+      assert Canvas.render_to_strings(canvas) ===
+               [
+                 "┌─Highlighted Ti",
                  "│              │",
                  "│ Body content │",
                  "└──────────────┘"

--- a/test/ratatouille/renderer/element/panel_test.exs
+++ b/test/ratatouille/renderer/element/panel_test.exs
@@ -11,9 +11,10 @@ defmodule Ratatouille.Renderer.Element.PanelTest do
                        label(content: "Body content")
                      end)
 
-  @panel_with_highlighted_title (panel title: "Highlighted Title", color: color(:red) do
-                       label(content: "Body contentt")
-    end)
+  @panel_with_highlighted_title (panel title: "Highlighted Title",
+                                       color: color(:red) do
+                                   label(content: "Body contentt")
+                                 end)
 
   @panel_with_explicit_height panel(height: 5)
 

--- a/test/ratatouille/renderer/element/panel_test.exs
+++ b/test/ratatouille/renderer/element/panel_test.exs
@@ -11,7 +11,7 @@ defmodule Ratatouille.Renderer.Element.PanelTest do
                        label(content: "Body content")
                      end)
 
-  @panel_with_highlighted_title (panel title: {"Highlighted Title", [color: color(:red)] } do
+  @panel_with_highlighted_title (panel title: "Highlighted Title", color: color(:red) do
                        label(content: "Body contentt")
     end)
 


### PR DESCRIPTION
 I missed the possibility to highlight a panel's title. 

With these changes, you can use `panel title: "Some Text"` as before or pass extra attributes which will be forwarded to the `text(...)` function for panel's title.

```
    panel title: { "The Text", [ background: color(:white), color: color(:black)]}
```