### PR TITLE
add documentation about child elements

### DIFF
--- a/lib/ratatouille/view.ex
+++ b/lib/ratatouille/view.ex
@@ -166,6 +166,12 @@ defmodule Ratatouille.View do
       end
 
     if length(spec[:child_tags]) > 0 do
+      allowed_children =
+        Enum.map(spec[:child_tags], fn child ->
+          " * #{Atom.to_string(child)}"
+        end)
+        |> Enum.join("\n")
+
       @doc """
       Defines an element with the `:#{name}` tag.
 
@@ -237,10 +243,15 @@ defmodule Ratatouille.View do
 
           #{name}([key: value], [elem1, elem2])
 
+      ## Allowed Child Elements:
+
+        #{allowed_children}
+
       """
       defmacro unquote(name)(attributes, children) do
         macro_element(unquote(name), attributes, children)
       end
+
     else
       @doc """
       Defines an element with the `:#{name}` tag.


### PR DESCRIPTION
When working with the library I spent a good deal of time just figuring out what the expected structure was for a more complex multi pane layout. I think that by documenting the allowed child elements it makes that expected structure more clear. For example it becomes more clear that something like `view row column pane` is how layouts are supposed to be laid out. 

This change adds a list of the supported children to every element in the documentation section for elements that accept children.
Example in column:
![image](https://user-images.githubusercontent.com/827851/55205271-90f76a00-51a8-11e9-92e3-77921c0f6262.png)


Thanks for creating Ratatouille! It's an awesome project. I'm really loving the API as a primary web developer who enjoys Elm and HyperApp. Note I'm super new to actual production elixir code so I wouldn't be surprised if I did something totally wrong. Just let me know and I'll fix it.