### PR TITLE
Support East Asian characters and Emojis

### DIFF
--- a/lib/ratatouille/renderer/text.ex
+++ b/lib/ratatouille/renderer/text.ex
@@ -14,11 +14,23 @@ defmodule Ratatouille.Renderer.Text do
     cells =
       text
       |> String.graphemes()
-      |> Enum.with_index()
+      |> with_positions()
       |> Enum.map(cell_generator)
 
     Canvas.merge_cells(canvas, cells)
   end
+
+  defp with_positions(graphemes) do
+    {positioned, _} =
+      graphemes
+      |> Enum.reduce({[], 0}, fn grapheme, {acc, pos} ->
+        {[{grapheme, pos} | acc], pos + char_width(grapheme)}
+      end)
+
+    positioned
+  end
+
+  def char_width(char), do: Ucwidth.width(char)
 
   def render_group(canvas, text_elements, attrs \\ %{}) do
     rendered_canvas =

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule Ratatouille.Mixfile do
     [
       {:ex_termbox, "~> 1.0"},
       {:asciichart, "~> 1.0"},
+      {:ucwidth, "~> 0.2"},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:dialyze, "~> 0.2.0", only: :dev},
       {:credo, "~> 1.3.0", only: [:dev, :test], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -11,4 +11,5 @@
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
+  "ucwidth": {:hex, :ucwidth, "0.2.0", "1f0a440f541d895dff142275b96355f7e91e15bca525d4a0cc788ea51f0e3441", [:mix], [], "hexpm", "c1efd1798b8eeb11fb2bec3cafa3dd9c0c3647bee020543f0340b996177355bf"},
 }


### PR DESCRIPTION
There is [an issue](https://github.com/ndreynolds/ex_termbox/issues/4) for Ratatouille to display **wide** characters correctly, especially East Asian characters and Emojis. [This script](https://gist.github.com/qhwa/3ff6e17f117b30961a41a084d693c886) can help reproduce the problem.

So I created a library, [ucwidtt](https://github.com/qhwa/elixir-ucwidth) to help solve this problem. As you can see, Ucwidth is used here to determine the width of a character. With the width calculated, we can make sure there is enough room for a single character.

So far it works great in my project. Please let me know if there's anything I'm missing?