### PR TITLE
Add support for extended color palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2020-04-27
+
 ### Changed
 
+* Added support for extended colors
 
 ## [0.5.0] - 2019-04-28
 

--- a/lib/ratatouille/renderer/attributes.ex
+++ b/lib/ratatouille/renderer/attributes.ex
@@ -6,10 +6,11 @@ defmodule Ratatouille.Renderer.Attributes do
   alias Ratatouille.Constants
 
   @valid_color_codes Constants.colors() |> Map.values()
+  @valid_color_codes_extended 0x11..0xe8
   @valid_attribute_codes Constants.attributes() |> Map.values()
 
   def to_terminal_color(code)
-      when is_integer(code) and code in @valid_color_codes do
+  when is_integer(code) and code in @valid_color_codes or code in @valid_color_codes_extended do
     code
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ratatouille.Mixfile do
   def project do
     [
       app: :ratatouille,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/ratatouille/renderer/attributes_test.exs
+++ b/test/ratatouille/renderer/attributes_test.exs
@@ -13,6 +13,10 @@ defmodule Ratatouille.Renderer.AttributesTest do
                Constants.color(:red)
     end
 
+    test "with extended color" do
+      assert Attributes.to_terminal_color(17) == 17
+    end
+
     test "when invalid" do
       assert_raise KeyError, fn ->
         Attributes.to_terminal_color(1000)


### PR DESCRIPTION
## Wat

Adds support for the extended color palette and closes out #14

## How

* Adds the extended color ranges as a module attribute

## Testing

* Added a test to make sure values in the new color range are accepted

## Notes

Please let me know if you need any changes made. I updated the `mix.exs` version and changelog to hopefully save you time, happy to revert them if you'd prefer to change 'em yourself...

Also, I could test the whole range, but figured one was enough 🤷 just let me know what you'd prefer.

Thanks!