### PR TITLE
Strip final newline from Asciichart output

### DIFF
--- a/lib/ratatouille/renderer/element/chart.ex
+++ b/lib/ratatouille/renderer/element/chart.ex
@@ -27,7 +27,7 @@ defmodule Ratatouille.Renderer.Element.Chart do
   end
 
   defp render_chart(%Canvas{render_box: box} = canvas, chart) do
-    lines = String.split(chart, "\n")
+    lines = chart |> String.trim |> String.split("\n")
 
     lines
     |> Enum.with_index()


### PR DESCRIPTION
When rendering a chart element, the final newline from Asciichart is still included in the final render. This PR `trim()`'s the output before splitting it, ensuring that no extra newlines are included after the chart. 