### PR TITLE
Add support for specific padding

### DIFF
--- a/lib/ratatouille/renderer/box.ex
+++ b/lib/ratatouille/renderer/box.ex
@@ -69,10 +69,10 @@ defmodule Ratatouille.Renderer.Box do
     }
   end
 
-  def padded(%Box{top_left: top_left, bottom_right: bottom_right}, size) do
+  def padded(%Box{top_left: top_left, bottom_right: bottom_right}, [top: top, left: left, bottom: bottom, right: right]) do
     %Box{
-      top_left: top_left |> Position.translate(size, size),
-      bottom_right: bottom_right |> Position.translate(-size, -size)
+      top_left: top_left |> Position.translate(left, top),
+      bottom_right: bottom_right |> Position.translate(-right, -bottom)
     }
   end
 

--- a/lib/ratatouille/renderer/canvas.ex
+++ b/lib/ratatouille/renderer/canvas.ex
@@ -70,8 +70,8 @@ defmodule Ratatouille.Renderer.Canvas do
   left, bottom, right) by `size`. Pass a negative size to remove padding.
   """
   @spec padded(Canvas.t(), integer()) :: Canvas.t()
-  def padded(%Canvas{render_box: box} = canvas, size) do
-    %Canvas{canvas | render_box: Box.padded(box, size)}
+  def padded(%Canvas{render_box: box} = canvas, [top: top, left: left, bottom: bottom, right: right]) do
+    %Canvas{canvas | render_box: Box.padded(box, top: top, left: left, bottom: bottom, right: right)}
   end
 
   @doc """

--- a/lib/ratatouille/renderer/element.ex
+++ b/lib/ratatouille/renderer/element.ex
@@ -116,7 +116,11 @@ defmodule Ratatouille.Renderer.Element do
       renderer: Overlay,
       child_tags: @content_tags,
       attributes: [
-        padding: {:optional, "Integer number of units of padding"}
+        padding: {:optional, "Integer number of units of padding"},
+        top: {:optional, "Integer number of units of top padding"},
+        left: {:optional, "Integer number of units of left padding"},
+        bottom: {:optional, "Integer number of units of bottom padding"},
+        right: {:optional, "Integer number of units of right padding"}
       ]
     ],
     panel: [
@@ -128,9 +132,11 @@ defmodule Ratatouille.Renderer.Element do
         color: {:optional, "Color of title"},
         background: {:optional, "Background of title"},
         attributes: {:optional, "Attributes for the title"},
-        padding:
-          {:optional,
-           "Integer providing inner padding to use when rendering child elements"},
+        padding: {:optional, "Integer providing inner padding to use when rendering child elements"},
+        top: {:optional, "Integer number of units of top padding"},
+        left: {:optional, "Integer number of units of left padding"},
+        bottom: {:optional, "Integer number of units of bottom padding"},
+        right: {:optional, "Integer number of units of right padding"},
         height:
           {:optional,
            "Height of the table in rows or `:fill` to fill the parent container's box"},

--- a/lib/ratatouille/renderer/element/overlay.ex
+++ b/lib/ratatouille/renderer/element/overlay.ex
@@ -4,17 +4,24 @@ defmodule Ratatouille.Renderer.Element.Overlay do
 
   alias Ratatouille.Renderer.{Canvas, Element}
 
+  @default_padding 10
+
   @impl true
   def render(
         %Canvas{outer_box: outer_box} = canvas,
         %Element{attributes: attrs, children: children},
         render_fn
       ) do
-    padding = attrs[:padding] || 10
+
+    padding = attrs[:padding] || @default_padding
+    top = attrs[:top] || padding
+    left = attrs[:left] || padding
+    bottom = attrs[:bottom] || padding
+    right = attrs[:right] || padding
 
     canvas
     |> Canvas.put_box(outer_box)
-    |> Canvas.padded(padding)
+    |> Canvas.padded(top: top, left: left, bottom: bottom, right: right)
     |> Canvas.fill_background()
     |> render_fn.(children)
   end

--- a/lib/ratatouille/renderer/element/panel.ex
+++ b/lib/ratatouille/renderer/element/panel.ex
@@ -28,11 +28,17 @@ defmodule Ratatouille.Renderer.Element.Panel do
       ) do
     fill_empty? = !is_nil(attrs[:height])
     constrained_canvas = constrain_canvas(canvas, attrs[:height])
-    padding = attrs[:padding] || @default_padding
+
+    padding = (attrs[:padding] || @default_padding) + @border_width
+
+    top = if attrs[:top], do: attrs[:top] + @border_width, else: padding
+    left = if attrs[:left], do: attrs[:left] + @border_width, else: padding
+    bottom = if attrs[:bottom], do: attrs[:bottom] + @border_width, else: padding
+    right = if attrs[:right], do: attrs[:right] + @border_width, else: padding
 
     rendered_canvas =
       constrained_canvas
-      |> Canvas.padded(padding + @border_width)
+      |> Canvas.padded(top: top, left: left, bottom: bottom, right: right)
       |> render_fn.(children)
       |> wrapper_canvas(constrained_canvas, fill_empty?)
       |> render_features(attrs)


### PR DESCRIPTION
This add support for specifying the padding for either `top`, `left`, `bottom` and `right` and will fallback to the default `padding` otherwise.